### PR TITLE
feat(auth): add production URLs to callback and logout URLs

### DIFF
--- a/amplify/auth/resource.ts
+++ b/amplify/auth/resource.ts
@@ -32,8 +32,16 @@ export const auth = defineAuth({
         },
       },
 
-      callbackUrls: ['http://localhost:3000', 'https://www.dev.fasttify.com/'],
-      logoutUrls: ['http://localhost:3000/login', 'https://www.dev.fasttify.com/login'],
+      callbackUrls: [
+        'http://localhost:3000',
+        'https://www.dev.fasttify.com/',
+        'https://www.fasttify.com/',
+      ],
+      logoutUrls: [
+        'http://localhost:3000/login',
+        'https://www.dev.fasttify.com/login',
+        'https://www.fasttify.com/login',
+      ],
     },
   },
 


### PR DESCRIPTION
This commit adds the production URL 'https://www.fasttify.com/' to both the callback and logout URLs in the auth configuration, ensuring seamless authentication flow in the production environment.