### PR TITLE
fix(userStore): correct typo in 'dentities' to 'identities'

### DIFF
--- a/context/core/userStore.ts
+++ b/context/core/userStore.ts
@@ -11,7 +11,7 @@ interface User {
   phone?: string
   cognitoUsername?: string
   userId?: string
-  dentities?: unknown[]
+  identities?: unknown[]
 }
 
 // Define el estado y las acciones del store


### PR DESCRIPTION
This commit fixes a typo in the `User` interface where the property `dentities` was incorrectly named. It has been corrected to `identities` to ensure proper functionality and consistency in the codebase.