### PR TITLE
refactor: replace `unknown[]` with `any[]` for `identities` type

### DIFF
--- a/context/core/userStore.ts
+++ b/context/core/userStore.ts
@@ -11,7 +11,7 @@ interface User {
   phone?: string
   cognitoUsername?: string
   userId?: string
-  identities?: unknown[]
+  identities?: any[]
 }
 
 // Define el estado y las acciones del store

--- a/hooks/auth/useAuthUser.ts
+++ b/hooks/auth/useAuthUser.ts
@@ -11,7 +11,7 @@ interface UserPayload {
   userId: string
   plan?: string
   picture?: string
-  identities?: unknown[]
+  identities?: any[]
   [key: string]: any
 }
 


### PR DESCRIPTION
The change simplifies the type definition for `identities` in both `UserPayload` and `User` interfaces by replacing `unknown[]` with `any[]`. This improves maintainability and reduces complexity while maintaining the same functionality.