### PR TITLE
refactor(useUserStores): remove onboarding filter to include all stores

### DIFF
--- a/app/(setup-layout)/my-store/hooks/useUserStores.ts
+++ b/app/(setup-layout)/my-store/hooks/useUserStores.ts
@@ -55,8 +55,7 @@ async function fetchUserStores(userId: string, userPlan?: string) {
       selectionSet: ['storeId', 'storeName', 'storeType', 'onboardingCompleted'],
     })
 
-    // Filtrar solo las tiendas con onboarding completado para mostrar
-    const completedStores = allUserStores?.filter(store => store.onboardingCompleted === true) || []
+    const completedStores = allUserStores || []
 
     // Verificar límite de tiendas según el plan
     const currentCount = allUserStores?.length || 0


### PR DESCRIPTION
The filter for onboarding completed stores was removed to ensure all user stores are returned, regardless of their onboarding status. This change aligns with the requirement to display all stores for the user, not just those with completed onboarding.