### PR TITLE
chore(amplify): add Node.js version 22 installation in preBuild phase

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-22
+corepack-disable

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,12 +1,22 @@
 version: 1
 backend:
   phases:
+    preBuild:
+      commands:
+        - nvm install 22
+        - nvm use 22
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
+
 frontend:
   phases:
+    preBuild:
+      commands:
+        - nvm install 22
+        - nvm use 22
+        - npm ci
     build:
       commands:
         - npm run build


### PR DESCRIPTION
This commit updates the amplify.yml file to include commands for installing and using Node.js version 22 in both the backend and frontend preBuild phases. This ensures a consistent Node.js environment during the build process.