### PR TITLE
chore(amplify): remove Node.js installation command from preBuild phase

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -14,7 +14,6 @@ frontend:
   phases:
     preBuild:
       commands:
-        - nvm install 22
         - nvm use 22
         - npm ci
     build:

--- a/app/store/[slug]/products/inventory/page.tsx
+++ b/app/store/[slug]/products/inventory/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { InventoryManager } from '@/app/store/components/product-management/InventoryManager'
+import { InventoryManager } from '@/app/store/components/product-management/main-components/InventoryManager'
 import { Amplify } from 'aws-amplify'
 import { getStoreId } from '@/utils/store-utils'
 import { useParams, usePathname } from 'next/navigation'


### PR DESCRIPTION
This commit simplifies the amplify.yml file by removing the explicit Node.js installation command, relying instead on the nvm use command to ensure the correct version is utilized during the build process. Additionally, it updates the import path for the InventoryManager component to reflect its new location in the main-components directory, improving code organization.