### PR TITLE
chore(amplify): remove unnecessary preBuild commands in amplify.yml

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,21 +1,12 @@
 version: 1
 backend:
   phases:
-    preBuild:
-      commands:
-        - nvm install 22
-        - nvm use 22
     build:
       commands:
         - npm ci --cache .npm --prefer-offline
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
-
 frontend:
   phases:
-    preBuild:
-      commands:
-        - nvm use 22
-        - npm ci 
     build:
       commands:
         - npm run build


### PR DESCRIPTION
This commit simplifies the amplify.yml configuration by removing redundant preBuild commands related to Node version management and npm installation, streamlining the build process for both backend and frontend phases.