### PR TITLE
chore(package): remove prepare script for husky from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "prepare": "husky",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"


### PR DESCRIPTION
This commit removes the "prepare" script for husky from package.json, simplifying the build configuration and potentially improving the installation process.