### PR TITLE
fix(themes): Increase S3 save timeout

### DIFF
--- a/app/api/stores/[storeId]/themes/confirm/route.ts
+++ b/app/api/stores/[storeId]/themes/confirm/route.ts
@@ -332,7 +332,7 @@ async function storeLargeFileInChunks(
   // Almacenar con timeout
   const storagePromise = s3Storage.storeTheme(processedTheme, storeId, processedFile);
   const timeoutPromise = new Promise((_, reject) => {
-    setTimeout(() => reject(new Error('S3 storage timeout')), 25000); // 25 segundos timeout
+    setTimeout(() => reject(new Error('S3 storage timeout')), 120000); // 120 segundos timeout
   });
 
   try {


### PR DESCRIPTION
- The save timeout for themes on S3 has been increased from 25 to 120 seconds to improve handling of large files.