### PR TITLE
feat(themes): Updated CDN URL generation during theme creation

### DIFF
--- a/app/api/stores/[storeId]/themes/confirm/route.ts
+++ b/app/api/stores/[storeId]/themes/confirm/route.ts
@@ -5,6 +5,7 @@ import {
   type ThemeStorageResult,
 } from '@/renderer-engine/services/themes/storage/s3-storage-service';
 import { AuthGetCurrentUserServer, cookiesClient } from '@/utils/client/AmplifyUtils';
+import { getCdnUrlForKey } from '@/utils/server';
 import { GetObjectCommand, HeadObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -70,6 +71,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
     // Crear placeholder en DB antes de responder (para garantizar registro aun si el background se corta)
     let themeId: string | undefined;
+    const cdnUrl = getCdnUrlForKey(`templates/${storeId}/theme.zip`);
     try {
       const { data: placeholder, errors: placeholderErrors } = await cookiesClient.models.UserTheme.create({
         storeId,
@@ -78,7 +80,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         author: themeData?.theme?.author || 'Unknown',
         description: themeData?.theme?.description || '',
         s3Key: '',
-        cdnUrl: '',
+        cdnUrl: cdnUrl,
         fileCount: themeData?.theme?.fileCount || 0,
         totalSize: themeData?.theme?.totalSize || 0,
         isActive: false,

--- a/app/api/stores/template/route.ts
+++ b/app/api/stores/template/route.ts
@@ -142,7 +142,7 @@ export async function POST(request: NextRequest) {
 
     // 7. Crear registro del tema en la DB con la información validada
     try {
-      const s3FolderKey = `templates/${storeId}/`
+      const s3FolderKey = `templates/${storeId}`
       const baseUrl = getCdnBaseUrl()
 
       const totalBytes = themeFiles.reduce((sum, f) => sum + (Number(f.size) || 0), 0)
@@ -154,7 +154,7 @@ export async function POST(request: NextRequest) {
         author: themeInfo.author || 'System',
         description: themeInfo.description || storeData?.description || 'Tema inicial de la tienda',
         s3Key: s3FolderKey,
-        cdnUrl: `${baseUrl}/${s3FolderKey}`,
+        cdnUrl: `${baseUrl}/${s3FolderKey}/theme.zip`,
         fileCount: copyResults.length,
         totalSize: totalBytes,
         isActive: true,


### PR DESCRIPTION
- Added the `getCdnUrlForKey` function to centrally generate CDN URLs when creating a theme.
- Updated the database record creation logic to include the correct CDN URL for the `theme.zip` file.
- Optimized the construction of the S3 folder key by removing the unnecessary trailing slash.