### PR TITLE
Potential fix for code scanning alert no. 50: Uncontrolled data used in path expression

### DIFF
--- a/packages/renderer-engine/services/templates/sync/template-dev-synchronizer.ts
+++ b/packages/renderer-engine/services/templates/sync/template-dev-synchronizer.ts
@@ -23,6 +23,11 @@ import * as chokidar from 'chokidar';
 import fs from 'fs';
 import path from 'path';
 
+// Define the root directory for allowed local template development folders.
+// You may change this to a different directory as appropriate for your setup.
+// E.g., use process.env.TEMPLATES_DEV_ROOT or a predetermined safe location.
+const TEMPLATES_DEV_ROOT = path.resolve(process.env.TEMPLATES_DEV_ROOT || '/srv/app/templates-dev-root');
+
 interface SyncOptions {
   localDir: string;
   storeId: string;
@@ -75,7 +80,15 @@ export class TemplateDevSynchronizer {
       await this.stop();
     }
 
-    this.localDir = path.resolve(options.localDir);
+    // Always resolve relative to our safe root
+    const requestedDir = path.resolve(options.localDir);
+    // Strict containment check: normalized requestedDir must start with the normalized root
+    if (!requestedDir.startsWith(TEMPLATES_DEV_ROOT + path.sep)) {
+      throw new Error(
+        `Directorio local ilegal: ${options.localDir}. Solo se permiten carpetas dentro de ${TEMPLATES_DEV_ROOT}.`
+      );
+    }
+    this.localDir = requestedDir;
     this.storeId = options.storeId;
 
     if (options.bucketName) {


### PR DESCRIPTION
Potential fix for [https://github.com/Fasttify/fasttify/security/code-scanning/50](https://github.com/Fasttify/fasttify/security/code-scanning/50)

To address this issue, we should ensure that any user-supplied directory is constrained to a predetermined safe root directory. This means that after normalizing the user-supplied path (with `path.resolve()`), we must check that the resulting path is contained within a specific root (e.g., a project-specific data directory, such as `/home/app/data/templates/{storeId}`). The safest way is to define a base directory for template development (e.g., `TEMPLATES_DEV_ROOT`), and only allow synchronization where the resolved `localDir` starts with this base path. If the resolved path does not start with the allowed base directory, an error should be thrown and the operation aborted.

The fix should be applied in `packages/renderer-engine/services/templates/sync/template-dev-synchronizer.ts`, specifically in the `start()` method.  
**Required changes:**
  1. Define a project-level safe root directory for local templates (can use an environment variable or hardcode for now).
  2. In `start()`, after resolving `options.localDir`, verify that `this.localDir` is a descendant of the safe root. If not, throw an error.
  3. Optionally, clarify the error message for easier debugging.

**Dependencies:**  
No new packages are needed unless you want to use `sanitize-filename`, but the recommended method is the root check using Node's built-in `path`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
