### PR TITLE
chore: Update Amplify configuration to use pnpm 10.18.0

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -3,14 +3,14 @@ backend:
   phases:
     build:
       commands:
-        - corepack enable
+        - npm install -g pnpm@10.18.0
         - pnpm install --frozen-lockfile
         - npx ampx pipeline-deploy --branch $AWS_BRANCH --app-id $AWS_APP_ID
 frontend:
   phases:
     build:
       commands:
-        - corepack enable
+        - npm install -g pnpm@10.18.0
         - env | grep -e BUCKET_NAME -e CLOUDFRONT_DOMAIN_NAME -e APP_URL -e APP_ENV -e REGION_BUCKET -e CLOUDFRONT_DISTRIBUTION_ID -e CLOUDFRONT_MULTI_TENANT_DISTRIBUTION_ID -e ANALYTICS_WEBHOOK_JWT_SECRET -e JWT_SECRET -e LAMBDA_EMAIL_BULK -e CLOUDFRONT_KEY_PAIR_ID -e CLOUDFRONT_PRIVATE_KEY >> .env.production
         - pnpm run build
   artifacts:


### PR DESCRIPTION
- Replace the CorePack enable command with the global installation of pnpm 10.18.0 in amplify.yml.
- Ensure dependencies are installed correctly with pnpm in the backend and frontend build phases.