### PR TITLE
fix: Remove Amplify cache configuration to resolve memory issues

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -28,9 +28,3 @@ frontend:
     baseDirectory: .next
     files:
       - '**/*'
-  cache:
-    paths:
-      - .amplify/**/*
-      - .next/cache/**/*
-      - .pnpm-store/**/*
-      - node_modules/**/*


### PR DESCRIPTION
- Eliminate cache paths that were causing out-of-memory errors
- Remove .amplify, .next/cache, .pnpm-store, and node_modules from cache
- Builds will be faster and more stable without cache overhead
- Dependencies will always be fresh, preventing corruption issues