### PR TITLE
Potential fix for code scanning alert no. 124: Incomplete URL substring sanitization

### DIFF
--- a/src/app/[store]/src/components/DevAutoReloadScript.tsx
+++ b/src/app/[store]/src/components/DevAutoReloadScript.tsx
@@ -38,11 +38,22 @@ export default function DevAutoReloadScript() {
       links.forEach((oldLink) => {
         if (!oldLink.href) return;
 
+        let parsedUrl: URL;
+        try {
+          parsedUrl = new URL(oldLink.href, window.location.origin);
+        } catch {
+          // Si la URL no es válida, no intentar hacer hot-swap.
+          return;
+        }
+
+        const hostname = parsedUrl.hostname;
+        const pathname = parsedUrl.pathname;
+
         // Ignorar CSS externos (Google Fonts, CDNs, etc.)
         if (
-          oldLink.href.includes('fonts.googleapis.com') ||
-          oldLink.href.includes('fonts.gstatic.com') ||
-          !oldLink.href.includes('/stores/')
+          hostname === 'fonts.googleapis.com' ||
+          hostname === 'fonts.gstatic.com' ||
+          !pathname.includes('/stores/')
         ) {
           return;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/Fasttify/fasttify/security/code-scanning/124](https://github.com/Fasttify/fasttify/security/code-scanning/124)

In general, the problem should be fixed by parsing the URL and inspecting its `hostname` (and optionally its `pathname`) instead of checking substrings on the raw URL string. For host checks, use `new URL(oldLink.href).hostname` and compare it exactly against a list of allowed or disallowed hostnames. For path checks, examine `url.pathname` rather than the full href. This eliminates cases where the keyword appears in query strings, fragments, or as part of another domain.

In this file, the best targeted fix is:

- Parse `oldLink.href` into a `URL` object at the beginning of the `links.forEach` callback.
- Replace the `oldLink.href.includes('fonts.googleapis.com')` and `oldLink.href.includes('fonts.gstatic.com')` checks with hostname comparisons on that `URL` object.
- Replace `!oldLink.href.includes('/stores/')` with a check on the `pathname` field of the parsed URL (`!url.pathname.includes('/stores/')`), which maintains existing behavior while avoiding substring checks on the full URL string.
- Keep the logic otherwise identical so functionality is preserved, including the `path` filter, which can still reasonably operate on the href as a string (it’s a dev-only path filter; if desired, it could also be made more precise by using `url.pathname`, but that’s not necessary to address the flagged issue).

No new libraries are needed; the built-in `URL` class is already available in the browser environment. The change is localized within `hotSwapCSS` in `src/app/[store]/src/components/DevAutoReloadScript.tsx`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only change that tightens URL parsing/filtering for stylesheet hot-reload; low risk but could prevent some CSS links from being hot-swapped if URLs are malformed or unexpected.
> 
> **Overview**
> Tightens the dev HMR CSS hot-swap logic in `DevAutoReloadScript` by parsing each stylesheet `href` with `URL` and filtering via exact `hostname` and `pathname` checks instead of substring matching.
> 
> Adds a safe fallback to skip hot-swapping when a stylesheet URL can’t be parsed, addressing the “incomplete URL substring sanitization” code scanning finding while keeping the rest of the reload behavior the same.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38c39770790416f7673e0471b19060d680f0c6db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->